### PR TITLE
fix: SignupResponseDTO에 패스워드 관련 필드 삭제

### DIFF
--- a/koview-server/src/main/java/com/koview/koview_server/member/domain/dto/SignupResponseDTO.java
+++ b/koview-server/src/main/java/com/koview/koview_server/member/domain/dto/SignupResponseDTO.java
@@ -11,17 +11,13 @@ import lombok.Getter;
 public class SignupResponseDTO {
     private final Long id;
     private final String email;
-    private final String loginPw;
-    private final String originLoginPw;
     private final String nickname;
     private final int age;
 
     /* Entity -> DTO */
-    public SignupResponseDTO(Member member, String originLoginPw) {
+    public SignupResponseDTO(Member member) {
         this.id = member.getId();
         this.email = member.getEmail();
-        this.loginPw = member.getLoginPw();
-        this.originLoginPw = originLoginPw;
         this.nickname = member.getNickname();
         this.age = member.getAge();
     }

--- a/koview-server/src/main/java/com/koview/koview_server/member/service/MemberServiceImpl.java
+++ b/koview-server/src/main/java/com/koview/koview_server/member/service/MemberServiceImpl.java
@@ -52,7 +52,7 @@ public class MemberServiceImpl implements MemberService {
         member.encodePassword(passwordEncoder);
         save(member);
 
-        return new SignupResponseDTO(member, signupRequestDTO.getLoginPw());
+        return new SignupResponseDTO(member);
     }
 
     @Override


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. SignupResponseDTO에 패스워드 관련 필드 삭제

### 성문님 체크

### 테스트 결과
#### 회원가입 결과
<img width="962" alt="스크린샷 2024-07-13 오후 10 41 03" src="https://github.com/user-attachments/assets/21528f1b-1f85-438b-9b82-809fc5ff608e">

