### PR TITLE
fix: 리뷰 전체 조회 및 나의 리뷰 전체 조회 API 리턴값 명시

### DIFF
--- a/koview-server/src/main/java/com/koview/koview_server/mypage/controller/MypageController.java
+++ b/koview-server/src/main/java/com/koview/koview_server/mypage/controller/MypageController.java
@@ -22,7 +22,7 @@ public class MypageController {
 
     @GetMapping("/myreview")
     @Operation(description = "나의 리뷰 전체 조회")
-    public ApiResult<?> findAllMyReview() {
+    public ApiResult<List<ReviewResponseDTO>> findAllMyReview() {
         List<ReviewResponseDTO> responseDTOs = reviewService.findAllByMember();
         return ApiResult.onSuccess(responseDTOs);
     }

--- a/koview-server/src/main/java/com/koview/koview_server/review/controller/ReviewController.java
+++ b/koview-server/src/main/java/com/koview/koview_server/review/controller/ReviewController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/review")
@@ -33,7 +35,7 @@ public class ReviewController {
 
     @GetMapping
     @Operation(description = "리뷰 전체 조회")
-    public ApiResult<?> getAllReviews() {
+    public ApiResult<List<ReviewResponseDTO>> getAllReviews() {
         return ApiResult.onSuccess(reviewService.findAll());
     }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. 리뷰 전체 조회 및 나의 리뷰 전체 조회 API 리턴값 명시
-> swagger에서 controller 리턴값이 ApiResult<?> 이면 request값이 제대로 안 보여서 ApiResult<List<<'DTO'>>>로 수정했습니다!

### 성문님 체크
- [x] QueryService가 붙는 클래스들은 gobal에 옮기는게 좋을 것 같아요!

### 테스트 결과
#### 리뷰 전체 조회 테스트 결과
![스크린샷 2024-07-14 오후 7 33 42](https://github.com/user-attachments/assets/d964d5bb-0acf-4178-9e56-c03151beaaef)

#### 나의 리뷰 전체 조회 테스트 결과
![스크린샷 2024-07-14 오후 7 33 15](https://github.com/user-attachments/assets/1978493c-bf59-444a-83db-ea4291d6cc9b)